### PR TITLE
feat: 添加 AI 服务抽象接口,同时支持openai和poe

### DIFF
--- a/main_config.yml
+++ b/main_config.yml
@@ -27,7 +27,13 @@ whitelist: [ ]
 # ------------------------------------------------------------------------------ #
 # 全局chatgpt设置，插件使用到，私聊gpt也使用到
 
+# AI 服务配置 (可选值: "openai" 或 "poe")
+ai_service_type: "openai"  
+
 #ChatGPT的API网址
 openai_api_base: ""
 #ChatGPT API的Key
 openai_api_key: ""
+
+# 添加 poe api 配置
+poe_api_key: ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ captcha~=0.5.0
 openpyxl~=3.1.5
 pynng~=0.8.0
 xmltodict~=0.13.0
+fastapi-poe==0.0.48

--- a/utils/ai_interface.py
+++ b/utils/ai_interface.py
@@ -1,0 +1,50 @@
+from abc import ABC, abstractmethod
+import fastapi_poe as fp
+from openai import AsyncOpenAI
+
+class AIInterface(ABC):
+    @abstractmethod
+    async def chat_completion(self, messages: list, **kwargs) -> tuple[bool, str]:
+        pass
+
+class OpenAIService(AIInterface):
+    def __init__(self, api_key: str, api_base: str):
+        self.client = AsyncOpenAI(api_key=api_key, base_url=api_base)
+
+    async def chat_completion(self, messages: list, **kwargs) -> tuple[bool, str]:
+        try:
+            response = await self.client.chat.completions.create(
+                messages=messages,
+                model=kwargs.get('model', 'gpt-3.5-turbo'),
+                temperature=kwargs.get('temperature', 0.7),
+                max_tokens=kwargs.get('max_tokens', 1000)
+            )
+            return True, response.choices[0].message.content
+        except Exception as e:
+            return False, str(e)
+
+class PoeService(AIInterface):
+    def __init__(self, api_key: str):
+        self.api_key = api_key
+
+    async def chat_completion(self, messages: list, **kwargs) -> tuple[bool, str]:
+        try:
+            poe_messages = []
+            for msg in messages:
+                role = "bot" if msg["role"] == "assistant" else msg["role"]
+                poe_messages.append(fp.ProtocolMessage(
+                    role=role,
+                    content=msg["content"]
+                ))
+
+            response_content = ""
+            async for partial in fp.get_bot_response(
+                messages=poe_messages,
+                bot_name=kwargs.get('model', 'gpt-3.5-turbo'),
+                api_key=self.api_key
+            ):
+                response_content += partial.text
+
+            return True, response_content
+        except Exception as e:
+            return False, str(e)


### PR DESCRIPTION
- 新增 AIInterface 抽象基类,定义统一的 chat_completion 接口
- 实现 OpenAIService 和 PoeService 两个具体服务类
- OpenAIService 封装 OpenAI API 调用
- PoeService 封装 Poe API 调用,支持消息格式自动转换
- 统一返回格式为 tuple[bool, str]

相关文件:
- plugins/text/private_chatgpt.py
- plugins/command/gpt.py 

POE的API KEY 测试没问题, openAI没有key所以没测,你看下改动,应该是没问题.