### PR TITLE
fix: 私聊时,不处理微信系统消息

### DIFF
--- a/plugins/text/private_chatgpt.py
+++ b/plugins/text/private_chatgpt.py
@@ -62,6 +62,9 @@ class private_chatgpt(PluginInterface):
         if gpt_request_message.startswith("我是"):  # 微信打招呼消息，不需要处理
             return
 
+        if wxid == "weixin":  # 微信系统消息, 不处理
+            return
+
         error = ''
         if self.db.get_points(wxid) < self.private_chat_gpt_price and wxid not in self.admins and not self.db.get_whitelist(wxid):  # 积分不够
             error = f"您的积分不足 {self.private_chat_gpt_price} 点，无法使用私聊GPT功能！⚠️"


### PR DESCRIPTION
触发了一个操作,机器人和微信系统消息进入循环聊天模式了...

日志:
2024-12-07 07:13:56 | INFO | [收到文本消息]:{'sender': 'weixin', 'roomid': 'weixin', 'type': 1, 'id': 5044394055407458607, 'content': '谢谢反馈', 'thumb': '', 'extra': '', 'from_group': False, 'from_self': False, 'is_text': True, 'is_at': <bound method XYBotWxMsg.is_at of <wcferry_helper.wcferry_helper.XYBotWxMsg object at 0x7fd5f7356330>>, 'xml': {'msgsource': {'tips': '3', 'bizmsg': {'bizmsgshowtype': '0', 'bizmsgfromuser': 'weixin'}, 'msg_cluster_type': '1', 'service_type': '1', 'scene': '5', 'signature': 'V1_cl6L09ov|v1_cl6L09ov', 'tmp_node': {'publisher-id': None}, 'sec_msg_node': {'alnode': {'fr': '1'}}}}, 'ats': [], 'join_group': ''}

![9321733555869_ pic](https://github.com/user-attachments/assets/1e4381c2-aa6a-4fb0-8723-5036ab3ea6ae)
